### PR TITLE
Expose waitTimeout to library consumers

### DIFF
--- a/packages/duplex-message/src/abstract.ts
+++ b/packages/duplex-message/src/abstract.ts
@@ -71,6 +71,11 @@ export function setConfig(options: Partial<ILibConfig>) {
 
 const CONTINUE_INDICATOR = '--message-hub-to-be-continued--'
 
+export interface IAbstractHubOptions {
+  /** how long to wait for response before erroring out with TIMEOUT. */
+  waitTimeout?: number;
+}
+
 export abstract class AbstractHub {
   /**
    * hub instance
@@ -96,14 +101,16 @@ export abstract class AbstractHub {
 
   /**
    * How long to wait for response before erroring out with TIMEOUT.
-   * @protected
    */
-  public waitTimeout = 200
+  private _waitTimeout: number
 
   /**
    * init Hub, subclass should implement its own constructor
    */
-  constructor() {
+  constructor(options?: IAbstractHubOptions) {
+    // eslint-disable-next-line no-param-reassign
+    options = { ...options, waitTimeout: 200 }
+    this._waitTimeout = options.waitTimeout!
     this.instanceID = AbstractHub.generateInstanceID()
     this._eventHandlerMap = []
     this._responseCallbacks = []
@@ -400,7 +407,7 @@ export abstract class AbstractHub {
         false,
       )
       this._runResponseCallback(resp)
-    }, this.waitTimeout)
+    }, this._waitTimeout)
   }
 
   protected static _wrapCallback(instance: AbstractHub, reqMsg: IRequest, callback: Function) {

--- a/packages/duplex-message/src/abstract.ts
+++ b/packages/duplex-message/src/abstract.ts
@@ -71,8 +71,6 @@ export function setConfig(options: Partial<ILibConfig>) {
 
 const CONTINUE_INDICATOR = '--message-hub-to-be-continued--'
 
-const WAIT_TIMEOUT = 200
-
 export abstract class AbstractHub {
   /**
    * hub instance
@@ -95,6 +93,12 @@ export abstract class AbstractHub {
    *  value: instanceID which will respond
    */
   protected _designedResponse: Record<string, string>
+
+  /**
+   * How long to wait for response before erroring out with TIMEOUT.
+   * @protected
+   */
+  public waitTimeout = 200
 
   /**
    * init Hub, subclass should implement its own constructor
@@ -396,7 +400,7 @@ export abstract class AbstractHub {
         false,
       )
       this._runResponseCallback(resp)
-    }, WAIT_TIMEOUT)
+    }, this.waitTimeout)
   }
 
   protected static _wrapCallback(instance: AbstractHub, reqMsg: IRequest, callback: Function) {

--- a/packages/duplex-message/src/page-script-message.ts
+++ b/packages/duplex-message/src/page-script-message.ts
@@ -3,11 +3,12 @@ import {
   IResponse,
   IHandlerMap,
   IRequest,
+  IAbstractHubOptions,
 } from './abstract'
 
 let sharedPageMessageHub: PageScriptMessageHub
 
-export interface IPageScriptMessageHubOptions {
+export interface IPageScriptMessageHubOptions extends IAbstractHubOptions {
   /** custom event name, default: message-hub */
   customEventName?: string
 }
@@ -25,7 +26,7 @@ export class PageScriptMessageHub extends AbstractHub {
     // eslint-disable-next-line no-param-reassign
     options = { customEventName: 'message-hub', ...options }
 
-    super()
+    super(options)
     this._customEventName = options.customEventName!
     this._onMessageReceived = this._onMessageReceived.bind(this)
     // @ts-ignore

--- a/packages/duplex-message/src/post-message.ts
+++ b/packages/duplex-message/src/post-message.ts
@@ -1,5 +1,5 @@
 import {
-  AbstractHub, IResponse, IRequest, IProgress, IHandlerMap, EErrorCode,
+  AbstractHub, IResponse, IRequest, IProgress, IHandlerMap, EErrorCode, IAbstractHubOptions,
 } from './abstract'
 
 type IOwnPeer = Window | Worker | undefined
@@ -16,6 +16,8 @@ function isWindow(peer:any): peer is Window {
   return !isInWorker && typeof window !== 'undefined' && peer instanceof Window
 }
 
+export interface IPostMessageHubOptions extends IAbstractHubOptions {}
+
 export class PostMessageHub extends AbstractHub {
   protected _hostedWorkers: Worker[]
 
@@ -23,8 +25,8 @@ export class PostMessageHub extends AbstractHub {
 
   protected readonly _isInWorker: boolean
 
-  constructor() {
-    super()
+  constructor(options?: IPostMessageHubOptions) {
+    super(options)
     this._hostedWorkers = []
     // save current window it's self
     // eslint-disable-next-line no-restricted-globals

--- a/packages/duplex-message/src/storage-message.ts
+++ b/packages/duplex-message/src/storage-message.ts
@@ -1,8 +1,8 @@
 import {
-  AbstractHub, IResponse, IHandlerMap, IRequest, IProgress,
+  AbstractHub, IResponse, IHandlerMap, IRequest, IProgress, IAbstractHubOptions,
 } from './abstract'
 
-export interface IStorageMessageHubOptions {
+export interface IStorageMessageHubOptions extends IAbstractHubOptions {
   /** localStorage key prefix to store message, default: $$xiu */
   keyPrefix?: string
   /**
@@ -26,7 +26,7 @@ export class StorageMessageHub extends AbstractHub {
         'StorageMessageHub only available in normal browser context, nodejs/worker are not supported',
       )
     }
-    super()
+    super(options)
     // eslint-disable-next-line no-param-reassign
     options = { keyPrefix: '$$xiu', ...options }
     this._onMessageReceived = this._onMessageReceived.bind(this)


### PR DESCRIPTION
Allow `waitTimeout` to be customized after hub is created.

**Rationale**

Sometimes, under a heavy load, 200ms isn't enough time for peer to respond. In situations when I know for a fact peer is there (having confirmed it prior), I want to increase the wait time to reduce the timeout error rate.